### PR TITLE
[codex] Set up 404 redirect map

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,8 +2,11 @@
 <head>
   <script>
     setTimeout(function() {
-      const q = new URL(window.location.href);
-      const redirectTo = "https://github.com/blocktransfer/website/commit/fc9fdaf32362d655185a5815d38aeba29e0b1a4f#commitcomment-165082980";
+      const redirects = {
+        "/about/values": "https://github.com/blocktransfer/org-docs/blob/main/values.md"
+      };
+      const path = window.location.pathname.replace(/\/$/, "");
+      const redirectTo = redirects[path] || "https://github.com/blocktransfer/website/commit/fc9fdaf32362d655185a5815d38aeba29e0b1a4f#commitcomment-165082980";
       window.location.href = redirectTo;
     }, 0);
   </script>


### PR DESCRIPTION
## Summary

This PR updates the root `404.html` redirect behavior to support a path-specific redirect map.

- Adds a `redirects` map for arbitrary removed paths
- Routes `/about/values` to `https://github.com/blocktransfer/org-docs/blob/main/values.md`
- Keeps the existing GitHub commit-comment permalink as the default 404 fallback

## Why

The deleted values page needs to redirect to its new canonical document location without changing the base behavior for other 404s.

## Validation

- Inspected the final `404.html` diff
- Confirmed the branch is based on current `origin/main`
- No build or runtime tests were run; this is a static HTML script change